### PR TITLE
Configure Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: java
+
+jdk:
+- oraclejdk8
+
+env:
+- MAVEN_OPTS=-Xmx512m CL_LOG_ERRORS=stdout
+
+before_install:
+    - sudo apt-get update -qq
+    - sudo apt-get install -qq fglrx=2:8.960-0ubuntu1 opencl-headers
+
+notifications:
+  email:
+    - xiantrimble@gmail.com

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ It was previously hosted on [ochafik/nativelibs4java](http://github.com/ochafik/
 # Quick links
 
 [![Join the chat at https://gitter.im/ochafik/JavaCL](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ochafik/JavaCL?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://travis-ci.org/ctrimble/JavaCL.svg?branch=feature_travis-build)](https://travis-ci.org/ctrimble/JavaCL)
 
 * [CHANGELOG](https://github.com/ochafik/JavaCL/blob/master/CHANGELOG)
 * [FAQ](http://code.google.com/p/javacl/wiki/FAQ)


### PR DESCRIPTION
This PR adds a configuration file for [Travis CI](https://travis-ci.org).

Currently, [the build fails on Travis](https://travis-ci.org/ctrimble/JavaCL/builds/54525231). Specifically, there are some issues with the KernelTest, but at least this would get those issues exposed.  Before pulling this code:
- The badge in README.md will need updating.  It contains the path to my fork and the name of my feature branch.
- The notification section of the configuration file will need updating.  It contains my email address.
