### PR TITLE
Configure Maven Fork Test parameters

### DIFF
--- a/Core/pom.xml
+++ b/Core/pom.xml
@@ -73,7 +73,7 @@ For more info, please visit http://code.google.com/p/nativelibs4java/wiki/OpenCL
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
-                    <forkCount>1</forkCount>
+                    <forkCount>1.5C</forkCount>
                     <reuseForks>false</reuseForks>
                 </configuration>
 			</plugin>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
